### PR TITLE
Fix invalid cast in rows()

### DIFF
--- a/include/csv2/reader.hpp
+++ b/include/csv2/reader.hpp
@@ -281,7 +281,8 @@ public:
     size_t result{0};
     if (!buffer_ || buffer_size_ == 0)
       return result;
-    for (char *p = buffer_; (p = (char *)memchr(p, '\n', (buffer_ + buffer_size_) - p)); ++p)
+    for (const char *p = buffer_;
+         (p = static_cast<const char *>(memchr(p, '\n', (buffer_ + buffer_size_) - p))); ++p)
       ++result;
     return result;
   }


### PR DESCRIPTION
Hi, I've started using csv2 in my project but got the following error:

```
/Users/keichi/Projects/research/csv2/include/csv2/reader.hpp:284:16: error: cannot initialize a variable of type 'char *' with an lvalue
      of type 'const char *const'
    for (char *p = buffer_; (p = (char *)memchr(p, '\n', (buffer_ + buffer_size_) - p)); ++p)
```

This PR is a quick fix.