### PR TITLE
Fix .pc description and url

### DIFF
--- a/csv2.pc.in
+++ b/csv2.pc.in
@@ -1,7 +1,7 @@
 includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
-Description: @PROJECT_DESCRIPTION@
-URL: @PROJECT_HOMEPAGE_URL@
+Description: Fast CSV parser and writer for Modern C++
+URL: https://github.com/p-ranav/csv2/
 Version: @PROJECT_VERSION@
 Cflags: -I${includedir}


### PR DESCRIPTION
Fix .pc description and url.
PROJECT_DESCRIPTION and PROJECT_URL are
not set in the project command so they evaluate to nothing.
csv2 requires CMake 3.8 but setting HOMEPAGE_URL in
the project command is only available in CMake 3.12 and later
and the variables seem to only be used in the .pc file so
set the values instead of using substitution.