### PR TITLE
Fix unused variable warning

### DIFF
--- a/include/csv2/reader.hpp
+++ b/include/csv2/reader.hpp
@@ -247,7 +247,8 @@ public:
 
   size_t cols() const {
     size_t result{0};
-    for (const auto cell : header())
+    const auto row = header();
+    for (auto cell = row.begin(); cell != row.end(); ++cell)
       result += 1;
     return result;
   }


### PR DESCRIPTION
`cell` variable is unused here, I replaced range-based for with regular loop to silence it.