### PR TITLE
Add missing include and CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(csv2 INTERFACE
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
 
-if(CSV2_TEST)
+if(CSV2_BUILD_TESTS)
   add_subdirectory(test)
 endif()
 

--- a/include/csv2/writer.hpp
+++ b/include/csv2/writer.hpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <csv2/parameters.hpp>
 #include <fstream>
+#include <iterator>
 #include <string>
 #include <utility>
 #include <iostream>


### PR DESCRIPTION
Hello,

I am considering using this in a professional project. I notice that some small improvements are needed for this nice library.

First, on Linux with gcc, all warnings and pedantic activated. I get the following error about a missing iterator header.

Also, I tried to compile the tests, but the option is not properly linked to the test folders.

With this pull request, both issues should be fixed.