### PR TITLE
feat: conditionally enable mmap functionality

### DIFF
--- a/include/csv2/reader.hpp
+++ b/include/csv2/reader.hpp
@@ -1,7 +1,10 @@
 
 #pragma once
 #include <cstring>
+#if __has_include("sys/mman.h") || __has_include(<sys/mman.h>) || __has_include("windows.h") || __has_include(<windows.h>)
+#define __CSV2_HAS_MMAN_H__ 1
 #include <csv2/mio.hpp>
+#endif
 #include <csv2/parameters.hpp>
 #include <istream>
 #include <string>
@@ -15,13 +18,16 @@ template <class delimiter = delimiter<','>, class quote_character = quote_charac
           class first_row_is_header = first_row_is_header<true>,
           class trim_policy = trim_policy::trim_whitespace>
 class Reader {
+  #if __CSV2_HAS_MMAN_H__
   mio::mmap_source mmap_;          // mmap source
+  #endif
   const char *buffer_{nullptr};    // pointer to memory-mapped data
   size_t buffer_size_{0};          // mapped length of buffer
   size_t header_start_{0};         // start index of header (cache)
   size_t header_end_{0};           // end index of header (cache)
 
 public:
+  #if __CSV2_HAS_MMAN_H__
   // Use this if you'd like to mmap the CSV file
   template <typename StringType> bool mmap(StringType &&filename) {
     mmap_ = mio::mmap_source(filename);
@@ -31,6 +37,7 @@ public:
     buffer_size_ = mmap_.mapped_length();
     return true;
   }
+  #endif
 
   // Use this if you have the CSV contents
   // in an std::string already


### PR DESCRIPTION
* Only enable include of `csv2/mio.hpp` in `csv2/reader.hpp` if `sys/mman.h` or `windows.h` can be found
This helps on platforms such as ESP32 which do not have mmap support exposed through sys/mman.h (though they do have memory mapping support at a lower layer, so perhaps that could be utilized via a later PR).

Tested on ESP32 using the following code:

```c++
    //! [csv reader example]
    std::string csv_data =
      "filename, boxart filename, display name\n"
      "mario.nes, boxart/mario.jpg, Mario Bros.\n"
      "super_mario_1.nes, boxart/super_mario_bros_1.jpg, Super Mario Bros.\n"
      "super_mario_3.nes, boxart/super_mario_bros_3.jpg, Super Mario Bros. 3\n"
      "zelda.nes, boxart/zelda1.jpg, The Legend of Zelda\n"
      "zelda_2.nes, boxart/zelda2.jpg, The Legend of Zelda 2: the Adventure of Link\n"
      "mega_man.nes, boxart/megaman1.jpg, MegaMan\n"
      "metroid.nes, boxart/metroid1.jpg, Metroid\n"
      "pokemon_blue.gb, boxart/pokemon_blue.jpg, Pokemon Blue\n"
      "pokemon_red.gb, boxart/pokemon_red.jpg, Pokemon Red\n"
      "pokemon_yellow.gbc, boxart/pokemon_yellow.jpg, Pokemon Yellow\n"
      "links_awakening.gb, boxart/tloz_links_awakening.jpg, The Legend of Zelda: Link's Awakening\n"
      "links_awakening.gbc, boxart/tloz_links_awakening_dx.jpg, The Legend of Zelda: Link's Awakening DX";

    // create the csv reader object
    csv2::Reader<csv2::delimiter<','>,
                 csv2::quote_character<'"'>,
                 csv2::first_row_is_header<true>,
                 csv2::trim_policy::trim_whitespace> csv;
    if (csv.parse(csv_data)) {
      // print the header
      const auto header = csv.header();
      fmt::print("Header:\n\t");
      for (const auto cell: header) {
        std::string value;
        cell.read_value(value);
        fmt::print("'{}', ", value);
      }
      fmt::print("\n");
      // now print the items
      size_t row_index = 0;
      for (const auto row: csv) {
        fmt::print("Row {} values:\n\t", row_index);
        for (const auto cell: row) {
          std::string value;
          cell.read_value(value);
          fmt::print("'{}', ", value);
        }
        fmt::print("\n");
        row_index++;
      }
    }
    //! [csv reader example]
```

With the following output:
![CleanShot 2023-03-30 at 15 02 42](https://user-images.githubusercontent.com/213467/228951420-02a3cfcc-6886-4d06-8229-c3099a9be5c8.png)
