### PR TITLE
Correct fully resolved namespace in first readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 #include <csv2/reader.hpp>
 
 int main() {
-  csv2::Reader<delimiter<','>, 
-               quote_character<'"'>, 
-               first_row_is_header<true>,
-               trim_policy::trim_whitespace> csv;
+  csv2::Reader<csv2::delimiter<','>, 
+               csv2::quote_character<'"'>, 
+               csv2::first_row_is_header<true>,
+               csv2::trim_policy::trim_whitespace> csv;
                
   if (csv.mmap("foo.csv")) {
     const auto header = csv.header();


### PR DESCRIPTION
The code provided in the readme as a first example previously did not work when copied verbatim.

Given that the first example implied that `using namespace csv2` was not being used, it should also use correct namespaces for the policy objects.

This may only be an issue when using the single file header version?